### PR TITLE
Fix ESLint for Jest

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,7 +2,8 @@
   "parser": "@typescript-eslint/parser",
   "env": {
     "node": true,
-    "es2021": true
+    "es2021": true,
+    "jest": true
   },
   "parserOptions": {
     "ecmaVersion": "latest",


### PR DESCRIPTION
ESlint doesn't have a proper configuration for JEST and my [ESLitnt VS code extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) spits errors for any test file. This PR fixes that. 

![image](https://user-images.githubusercontent.com/23432278/182056389-f278d454-5e0c-4496-861a-3a51a324c1ab.png)

This is not caught by `npm run lint` since it only tests `src` folder. I have no idea if this is expected? I guess it would be a good idea to test both `src` and `test` directories.

https://github.com/TheDrone7/shieldbow/blob/bed6b69d3dc76fdc05e027aaf85998362a67d6de/package.json#L28

The docs for this config var are [here](https://eslint.org/docs/latest/user-guide/configuring/language-options).
