### PR TITLE
Disable pre-fetching by default

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -70,12 +70,11 @@ client.initialize({
 ```
 
 Before you run this code, make sure you have replaced `MY_API_KEY` with your API key.
-If you run the above code exactly as it is, it may seem like it is stuck (it's actually running).
+You can obtain it from [Riot Developer Portal](https://developer.riotgames.com). Whenever you are
+developing something or just fiddling around with this library, you are free to use the Development API key. Once you have a complete project
+you need to apply for production API key.
 
-This is because, by default, the client will fetch all patch data such as champions, items, runes, etc. during initialization.
-This slows down the initialization but actually helps a lot when actually making requests.
-
-Anyway, once the initialization completes, you will see something similar to the following data:
+Anyway, you will see something similar to the following data:
 ```
 Summoner name: TheDrone7 (level: 259).
 SoloQ: BRONZE III (9 LP).

--- a/src/client.ts
+++ b/src/client.ts
@@ -160,10 +160,10 @@ export class Client {
     }
 
     // Fetch the data and cache it for faster data retrieval.
-    if (options?.fetch?.champions ?? true) await this.champions.fetchAll();
-    if (options?.fetch?.items ?? true) await this.items.fetch('1001');
-    if (options?.fetch?.runes ?? true) await this.runes.fetch('Domination');
-    if (options?.fetch?.summonerSpells ?? true) await this.summonerSpells.fetch('SummonerFlash');
+    if (options?.fetch?.champions ?? false) await this.champions.fetchAll();
+    if (options?.fetch?.items ?? false) await this.items.fetch('1001');
+    if (options?.fetch?.runes ?? false) await this.runes.fetch('Domination');
+    if (options?.fetch?.summonerSpells ?? false) await this.summonerSpells.fetch('SummonerFlash');
   }
 
   /**


### PR DESCRIPTION
dragon Pre-Fetching is really a wonderful feature of this library. It really speed up any operations on any ddragon data. The problem I have with the current setup is that it's enabled by default. When users run the example form getting started they need to wait a minute for it to run:

![image](https://user-images.githubusercontent.com/23432278/182269316-e1a87ca4-ceda-4580-a209-28495123729b.png)

Obviously, the getting started guide explains that there is an initialization procedure that takes time and the client will appear stuck but, honestly, most people will just run the code and don't read the guide any further. This creates confusion since generally, API wrappers initialize themselves in just a couple of seconds. That's why I think it should be an opt-in feature.