### PR TITLE
Add shortcuts to client initialization

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -93,6 +93,14 @@ export class Client {
     this._patch = version !== 'null' ? version.match(patchRegex)!.shift()! : 'null';
     const language = options?.locale || 'null';
     if (language !== 'null') this._locale = language;
+    if (typeof options?.cache === 'boolean') options.cache = { enable: options.cache };
+    if (typeof options?.fetch === 'boolean')
+      options.fetch = {
+        champions: options?.fetch,
+        items: options?.fetch,
+        runes: options?.fetch,
+        summonerSpells: options?.fetch
+      };
 
     const enableCache = options?.cache?.enable ?? true;
     const cacheRoot = options?.cache?.localRoot || 'data';

--- a/src/types/ClientConfig.ts
+++ b/src/types/ClientConfig.ts
@@ -42,13 +42,15 @@ export interface PreFetchConfig {
 export interface ClientConfig {
   /**
    * The local caching settings.
+   * Alternatively, you can pass `true` or `false` to enable or disable caching without configuration.
    */
-  cache?: CacheConfig;
+  cache?: CacheConfig | boolean;
   /**
    * The data to fetch beforehand when initializing the client.
    * This can delay the initialization but makes the rest of the processes much faster.
+   * Alternatively, you can pass `true` or `false` to enable or disable all of the data fetching.
    */
-  fetch?: PreFetchConfig;
+  fetch?: PreFetchConfig | boolean;
   /**
    * The data dragon CDN version (defaults to latest as per the specified region)
    */

--- a/tests/champion.test.ts
+++ b/tests/champion.test.ts
@@ -48,11 +48,7 @@ describe('Test champion fetching.', () => {
   });
 
   test('Check champion assets', () => {
-    expect(kayn.defaultSplashArt).toBe(
-      'http://raw.communitydragon.org/pbe/plugins/rcp-be-lol-game-data/global/default/v1/champion-splashes/uncentered/141/141000.jpg'
-    );
-    expect(kayn.defaultLoadingScreen).toBe(
-      'https://raw.communitydragon.org/pbe/plugins/rcp-be-lol-game-data/global/default/assets/characters/kayn/skins/base/kaynloadscreen.jpg'
-    );
+    expect(kayn.defaultSplashArt).toBe('http://raw.communitydragon.org/pbe/plugins/rcp-be-lol-game-data/global/default/v1/champion-splashes/uncentered/141/141000.jpg')
+    expect(kayn.defaultLoadingScreen).toBe('https://raw.communitydragon.org/pbe/plugins/rcp-be-lol-game-data/global/default/assets/characters/kayn/skins/base/kaynloadscreen.jpg');
   });
 });

--- a/tests/champion.test.ts
+++ b/tests/champion.test.ts
@@ -7,13 +7,8 @@ describe('Test champion fetching.', () => {
 
   beforeAll(async () => {
     await client.initialize({
-      cache: { enable: false },
-      fetch: {
-        champions: false,
-        items: false,
-        runes: false,
-        summonerSpells: false
-      }
+      cache: false,
+      fetch: false
     });
     kayn = await client.champions.fetch('Kayn');
   });
@@ -34,7 +29,7 @@ describe('Test champion fetching.', () => {
     expect(kayn.spells.get('Q')!.name).toBe('Reaping Slash');
 
     expect(kayn.spells.has('W')).toBeTruthy();
-    expect(kayn.spells.get('W')!.name).toBe('Blade\'s Reach');
+    expect(kayn.spells.get('W')!.name).toBe("Blade's Reach");
 
     expect(kayn.spells.has('E')).toBeTruthy();
     expect(kayn.spells.get('E')!.name).toBe('Shadow Step');
@@ -53,7 +48,11 @@ describe('Test champion fetching.', () => {
   });
 
   test('Check champion assets', () => {
-    expect(kayn.defaultSplashArt).toBe('http://raw.communitydragon.org/pbe/plugins/rcp-be-lol-game-data/global/default/v1/champion-splashes/uncentered/141/141000.jpg')
-    expect(kayn.defaultLoadingScreen).toBe('https://raw.communitydragon.org/pbe/plugins/rcp-be-lol-game-data/global/default/assets/characters/kayn/skins/base/kaynloadscreen.jpg');
+    expect(kayn.defaultSplashArt).toBe(
+      'http://raw.communitydragon.org/pbe/plugins/rcp-be-lol-game-data/global/default/v1/champion-splashes/uncentered/141/141000.jpg'
+    );
+    expect(kayn.defaultLoadingScreen).toBe(
+      'https://raw.communitydragon.org/pbe/plugins/rcp-be-lol-game-data/global/default/assets/characters/kayn/skins/base/kaynloadscreen.jpg'
+    );
   });
 });

--- a/tests/clash.test.ts
+++ b/tests/clash.test.ts
@@ -8,15 +8,8 @@ describe('Test Clash v1 API', () => {
   beforeAll(async () => {
     await client.initialize({
       region: 'euw',
-      cache: {
-        enable: false
-      },
-      fetch: {
-        champions: false,
-        items: false,
-        runes: false,
-        summonerSpells: false
-      }
+      cache: false,
+      fetch: false
     });
     tournaments = await client.clash.fetchAll();
   });

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -5,13 +5,8 @@ describe('Test client configuration update', () => {
 
   beforeAll(async () => {
     await client.initialize({
-      cache: { enable: false },
-      fetch: {
-        champions: false,
-        items: false,
-        runes: false,
-        summonerSpells: false
-      }
+      cache: false,
+      fetch: false
     });
   });
 

--- a/tests/item.test.ts
+++ b/tests/item.test.ts
@@ -7,13 +7,8 @@ describe('Test item fetching.', () => {
 
   beforeAll(async () => {
     await client.initialize({
-      cache: { enable: false },
-      fetch: {
-        champions: false,
-        items: false,
-        runes: false,
-        summonerSpells: false
-      }
+      cache: false,
+      fetch: false
     });
     boots = await client.items.fetch('1001');
   });

--- a/tests/league.test.ts
+++ b/tests/league.test.ts
@@ -9,15 +9,8 @@ describe('Test league-v4 and league-exp-v4 API', () => {
   beforeAll(async () => {
     await client.initialize({
       region: 'euw',
-      cache: {
-        enable: false
-      },
-      fetch: {
-        champions: false,
-        items: false,
-        runes: false,
-        summonerSpells: false
-      }
+      cache: false,
+      fetch: false
     });
     const summoner = await client.summoners.fetchBySummonerName('TheDrone7');
     leagues = await summoner.fetchLeagueEntries();

--- a/tests/mastery.test.ts
+++ b/tests/mastery.test.ts
@@ -8,15 +8,8 @@ describe('Test Champion Mastery v4 API', () => {
   beforeAll(async () => {
     await client.initialize({
       region: 'euw',
-      cache: {
-        enable: false
-      },
-      fetch: {
-        champions: false,
-        items: false,
-        runes: false,
-        summonerSpells: false
-      }
+      cache: false,
+      fetch: false
     });
     const summoner = await client.summoners.fetchBySummonerName('TheDrone7');
     masteries = summoner.championMastery;

--- a/tests/match.test.ts
+++ b/tests/match.test.ts
@@ -11,13 +11,8 @@ describe('Test match v5 API', () => {
   beforeAll(async () => {
     await client.initialize({
       region: 'euw',
-      cache: { enable: false },
-      fetch: {
-        champions: false,
-        items: false,
-        runes: false,
-        summonerSpells: false
-      }
+      cache: false,
+      fetch: false
     });
     const summoner = await client.summoners.fetchBySummonerName('TheDrone7');
     matches = await client.matches.fetchMatchListByPlayer(summoner);

--- a/tests/rune.test.ts
+++ b/tests/rune.test.ts
@@ -8,13 +8,8 @@ describe('Test runes fetching.', () => {
 
   beforeAll(async () => {
     await client.initialize({
-      cache: { enable: false },
-      fetch: {
-        champions: false,
-        items: false,
-        runes: false,
-        summonerSpells: false
-      }
+      cache: false,
+      fetch: false
     });
     domination = await client.runes.fetch('Domination');
     electrocute = await client.runes.fetchRune('Electrocute');

--- a/tests/spectator.test.ts
+++ b/tests/spectator.test.ts
@@ -10,13 +10,8 @@ describe('Test Spectator v4 API', () => {
   beforeAll(async () => {
     await client.initialize({
       region: 'euw',
-      cache: { enable: false },
-      fetch: {
-        champions: false,
-        items: false,
-        runes: false,
-        summonerSpells: false
-      }
+      cache: false,
+      fetch: false
     });
     games = await client.spectator.fetchFeatured();
   });

--- a/tests/spell.test.ts
+++ b/tests/spell.test.ts
@@ -7,13 +7,8 @@ describe('Test summoner spells fetching.', () => {
 
   beforeAll(async () => {
     await client.initialize({
-      cache: { enable: false },
-      fetch: {
-        champions: false,
-        items: false,
-        runes: false,
-        summonerSpells: false
-      }
+      cache: false,
+      fetch: false
     });
     flash = await client.summonerSpells.fetch('SummonerFlash');
   });

--- a/tests/summoner.test.ts
+++ b/tests/summoner.test.ts
@@ -8,13 +8,8 @@ describe('Test Summoner v4 and Account v1 API', () => {
   beforeAll(async () => {
     await client.initialize({
       region: 'euw',
-      cache: { enable: false },
-      fetch: {
-        champions: false,
-        items: false,
-        runes: false,
-        summonerSpells: false
-      }
+      cache: false,
+      fetch: false
     });
     summoner = await client.summoners.fetchBySummonerName('TheDrone7');
   });


### PR DESCRIPTION
Hey, this PR adds the ability to simplify the initialization of the client. Initializing a client without cache and pre-fetching looks something like that:

```ts
await client.initialize({
	region: "eune",
	cache: { enable: false },
	fetch: {
		champions: false,
		items: false,
		runes: false,
		summonerSpells: false
	}
});
```
Now it can be done by just writing:
```ts
await client.initialize({
	region: "eune",
	cache: false,
	fetch: false
});
```
This also works the other way:
```ts
await client.initialize({
	region: "eune",
	cache: true,
	fetch:  true
});
```
I've also replaced all of the initialization in test to these shortcuts