### PR TITLE
Optimize and cleanup - `ChampionMasteryManager` &`ChampionManager`

### DIFF
--- a/docs/api/ChampionManager.md
+++ b/docs/api/ChampionManager.md
@@ -106,6 +106,32 @@ fetchAll(): Promise<Collection<string, Champion>>;
 
 ---
 
+#### .fetchByKey (key)
+
+Fetch and cache champion by their unique 3-digit keys.
+
+
+This is mostly for internal use while fetching match (or live match) data to improve performance.
+
+
+
+
+**Signature:**
+
+```ts
+fetchByKey(key: number): Promise<Champion | undefined>;
+```
+
+**Parameters:**
+
+| Parameter | Type | Description |
+| --------- | ---- | ----------- |
+| key | [Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number) | The key of the champions to fetch. |
+
+**Return type**: [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) \< [Champion](/api/Champion.md) \| [Undefined](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined) \>
+
+---
+
 #### .fetchByKeys (keys)
 
 Fetch and cache champions by their unique 3-digit keys.
@@ -119,7 +145,7 @@ This is mostly for internal use while fetching match (or live match) data to imp
 **Signature:**
 
 ```ts
-fetchByKeys(keys: number[]): Promise<unknown>;
+fetchByKeys(keys: number[]): Promise<Collection<string, Champion>>;
 ```
 
 **Parameters:**
@@ -128,7 +154,7 @@ fetchByKeys(keys: number[]): Promise<unknown>;
 | --------- | ---- | ----------- |
 | keys | [Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)[] | The keys of the champions to fetch. |
 
-**Return type**: [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) \< unknown \>
+**Return type**: [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) \< [Collection](https://discord.js.org/#/docs/collection/stable/class/Collection) \< [String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String), [Champion](/api/Champion.md) \> \>
 
 ---
 

--- a/docs/api/ChampionMasteryManager.md
+++ b/docs/api/ChampionMasteryManager.md
@@ -116,7 +116,7 @@ fetch(champion: Champion | string, options?: FetchOptions): Promise<ChampionMast
 
 ---
 
-#### .highest (n)
+#### .highest (n, options)
 
 Get the nth highest champion mastery for the summoner.
 
@@ -126,7 +126,7 @@ Get the nth highest champion mastery for the summoner.
 **Signature:**
 
 ```ts
-highest(n?: number): Promise<ChampionMastery>;
+highest(n?: number, options?: FetchOptions): Promise<ChampionMastery>;
 ```
 
 **Parameters:**
@@ -134,6 +134,7 @@ highest(n?: number): Promise<ChampionMastery>;
 | Parameter | Type | Description |
 | --------- | ---- | ----------- |
 | n | [Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number) | The ranking of the champion in the summoner's champions mastery, defaults to 0 (highest). |
+| options | [FetchOptions](/api/FetchOptions.md) |  |
 
 **Return type**: [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) \< [ChampionMastery](/api/ChampionMastery.md) \>
 

--- a/src/managers/ChampionMasteryManager.ts
+++ b/src/managers/ChampionMasteryManager.ts
@@ -113,9 +113,9 @@ export class ChampionMasteryManager implements BaseManager<ChampionMastery> {
   }
 
   /**
-   * Fetches all the champions's masteries data for this summoner and store them in the cache.
+   * Update the cache with the latest data for all champions' mastery data for this summoner.
    */
-  fetchAll() {
+  refreshAll() {
     return new Promise<Collection<string, ChampionMastery>>(async (resolve, reject) => {
       const dataList = (await this._fetchRawMasteryData().catch(reject)) as ChampionMasteryData[];
       // Fetch all champions that this summoners has any mastery points

--- a/src/managers/ChampionMasteryManager.ts
+++ b/src/managers/ChampionMasteryManager.ts
@@ -113,13 +113,6 @@ export class ChampionMasteryManager implements BaseManager<ChampionMastery> {
   }
 
   /**
-   * @deprecated use fetchAll instead
-   */
-  refreshAll() {
-    return this.fetchAll();
-  }
-
-  /**
    * Fetches all the champions's masteries data for this summoner and store them in the cache.
    */
   fetchAll() {

--- a/src/managers/ChampionMasteryManager.ts
+++ b/src/managers/ChampionMasteryManager.ts
@@ -172,7 +172,7 @@ export class ChampionMasteryManager implements BaseManager<ChampionMastery> {
   }
 
   /**
-   * Sort mastery by level and points in order M7 -> M6 -> M5.
+   * Sort mastery by level and points
    * Works for raw and parsed masteries
    */
   private _sortMastery(data: Collection<string, ChampionMastery> | ChampionMasteryData[]) {


### PR DESCRIPTION
That's a big one. I've improved the speed of `ChampionMasteryManager` by a lot while making some general cleanup.

ChampionManager
- I've added `ChampionManager.fetchByKey` function which works like `fetchByKeys` but for one champ key.
- `fetchByKeys` now has return addnotation since it was showing up as `Promise<unknown>`
- `fetchByKeys` now return actually fetched champions instead of whole cache. This isn't a breaking change since it's a bugfix.

ChampionMasteryManager
- `get sortedCache()` now uses `_sortMastery` function which support both `ChampionMasteryData[]` raw data from API and passed version `Collection<string, ChampionMastery>`. This can use this funny typescript thing `_sortMastery<T>(data; T): T` so it returns a valid type instead of union but I have no idea how to do it.
- `highest` now fetches only one champion from the dragon which speeds up getting started code from around 45 seconds to 3.04 seconds 🐎 with #13 it's really as fast as it can be!