### PR TITLE
Add missing promise reject for case when match data is malformed

### DIFF
--- a/src/managers/MatchManager.ts
+++ b/src/managers/MatchManager.ts
@@ -59,17 +59,20 @@ export class MatchManager implements BaseManager<Match> {
             params: 'Match ID: ' + id
           })
           .catch(reject);
-        if (response) {
-          const data = <MatchData>response.data;
-          await this.client.champions.fetchByKeys(data.info.participants.map((p) => p.championId));
+        if (response)
+          try {
+            const data = <MatchData>response.data;
+            await this.client.champions.fetchByKeys(data.info.participants.map((p) => p.championId));
 
-          if (this.client.items.cache.size === 0) await this.client.items.fetch('1001');
-          if (this.client.summonerSpells.cache.size === 0) await this.client.summonerSpells.fetchByName('Flash');
-          if (this.client.runes.cache.size === 0) await this.client.runes.fetch('Domination');
-          const match = new Match(this.client, data);
-          if (cache) this.cache.set(id, match);
-          resolve(match);
-        }
+            if (this.client.items.cache.size === 0) await this.client.items.fetch('1001');
+            if (this.client.summonerSpells.cache.size === 0) await this.client.summonerSpells.fetchByName('Flash');
+            if (this.client.runes.cache.size === 0) await this.client.runes.fetch('Domination');
+            const match = new Match(this.client, data);
+            if (cache) this.cache.set(id, match);
+            resolve(match);
+          } catch (e: any) {
+            reject(e);
+          }
       }
     });
   }

--- a/src/structures/Match.ts
+++ b/src/structures/Match.ts
@@ -121,7 +121,7 @@ export class Match {
    * Checks received match data for traits of a bugged match.
    * @param data - The raw match data from the API.
    */
-  private _isDataMalformed(data: MatchData) {
+  private _isDataMalformed(data: MatchData): boolean {
     if (data.info.gameCreation === 0) return true;
     if (data.info.gameDuration === 0) return true;
     if (data.info.gameMode.length === 0) return true;

--- a/src/structures/Match.ts
+++ b/src/structures/Match.ts
@@ -84,6 +84,7 @@ export class Match {
    * @param data - The raw match data from the API.
    */
   constructor(client: Client, data: MatchData) {
+    if (this._isDataMalformed(data)) throw new Error('Match data received is malformed.');
     this.client = client;
     this.id = data.metadata.matchId;
     this.version = data.metadata.dataVersion;
@@ -114,6 +115,22 @@ export class Match {
    */
   fetchTimeline(): Promise<MatchTimeline> {
     return this.client.matches.fetchMatchTimeline(this.id, { region: this.region });
+  }
+
+  /**
+   * Checks received match data for traits of a bugged match.
+   * @param data - The raw match data from the API.
+   */
+  private _isDataMalformed(data: MatchData) {
+    if (data.info.gameCreation === 0) return true;
+    if (data.info.gameDuration === 0) return true;
+    if (data.info.gameMode.length === 0) return true;
+    if (data.info.gameName.length === 0) return true;
+    if (data.info.gameType.length === 0) return true;
+    if (data.info.gameVersion.length === 0) return true;
+    if (data.info.participants.length === 0) return true;
+    if (data.info.teams.length === 0) return true;
+    return false;
   }
 
   private _regionFromPlatformId(platformId: string): Region {

--- a/tests/match.test.ts
+++ b/tests/match.test.ts
@@ -20,6 +20,19 @@ describe('Test match v5 API', () => {
     matchTimeline = await client.matches.fetchMatchTimeline(matches[0]);
   });
 
+  test('Check malformed match', async () => {
+    const client = new Client(process.env.RIOT_API_KEY!);
+    await client.initialize({
+      region: 'br',
+      cache: false
+    });
+    try {
+      await client.matches.fetch('BR1_2583580397');
+    } catch (e: any) {
+      if (e instanceof Error) expect(e.message).toMatch('malformed');
+    }
+  });
+
   test('Check match list fetching', () => {
     expect(matches.length).toBeGreaterThan(0);
     expect(matches[0]).toBe(match.id);


### PR DESCRIPTION
### Changes
* Add promise reject in `MatchManager` constructor when match data received is malformed.
* Add `_isDataMalformed` private function to `Match` to help with above.
* Add new error `Match data received is malformed.` for `Match` for use with above.
* Add new Jest unit test `Check malformed match`.

My attempt to solve #30 for matches that have malformed or bugged data. The `MatchManager` had a case where it can receive a match response with data but fails to use `reject()` for the constructed `Promise<Match>` when the raw match data is bad (missing participants, teams, gameName, etc). :bee_sad: