### PR TITLE
🌏 Add missing region values for SEA platforms

### DIFF
--- a/src/structures/api/Match.ts
+++ b/src/structures/api/Match.ts
@@ -166,6 +166,16 @@ export class Match {
         return 'tr';
       case 'RU':
         return 'ru';
+      case 'PH2':
+        return 'ph';
+      case 'SG2':
+        return 'sg';
+      case 'TH2':
+        return 'th';
+      case 'TW2':
+        return 'tw';
+      case 'VN2':
+        return 'vn';
       default:
         return 'na';
     }


### PR DESCRIPTION
I believe this fixes a bug where the `region` field for a match defaults to `'na'` when fetching a match from one of the below SEA platforms. :3

- [x] Add missing `'ph'`, `'sg'`, `'th'`, `'tw'`, and `'vn'` regions