### PR TITLE
Add arena support

### DIFF
--- a/docs/content/2.api/1.classes/Match.md
+++ b/docs/content/2.api/1.classes/Match.md
@@ -181,7 +181,7 @@ They are mapped by their map sides (`blue` and `red`).
 
 
 
-**Type**: [Collection](https://discord.js.org/#/docs/collection/stable/class/Collection) \< 'blue' \| 'red', [Team](/api/classes/team) \>
+**Type**: [Collection](https://discord.js.org/#/docs/collection/stable/class/Collection) \< 'blue' \| 'red' \| 'Poro' \| 'Minion' \| 'Scuttle' \| 'Krug', [Team](/api/classes/team) \>
 
 ---
 

--- a/docs/content/2.api/1.classes/Participant.md
+++ b/docs/content/2.api/1.classes/Participant.md
@@ -614,7 +614,7 @@ Team name of the participants team.
 
 
 
-**Type**: subteamNames
+**Type**: SubteamNames
 
 ---
 

--- a/docs/content/2.api/1.classes/Participant.md
+++ b/docs/content/2.api/1.classes/Participant.md
@@ -548,6 +548,76 @@ An overview of the physical damage dealt/taken by the participant.
 
 ---
 
+#### placement
+
+Participants placement in the Arena gamemode.
+
+
+
+**Type**: [Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)
+
+---
+
+#### playerAugment1
+
+1st participant augment in the Arena gamemode.
+
+
+
+**Type**: [Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)
+
+---
+
+#### playerAugment2
+
+2nd participant augment in the Arena gamemode.
+
+
+
+**Type**: [Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)
+
+---
+
+#### playerAugment3
+
+3rd participant augment in the Arena gamemode.
+
+
+
+**Type**: [Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)
+
+---
+
+#### playerAugment4
+
+4th participant augment in the Arena gamemode.
+
+
+
+**Type**: [Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)
+
+---
+
+#### playerSubteamId
+
+TeamId of the participant.
+
+
+
+**Type**: [Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)
+
+---
+
+#### playerSubteamName
+
+Team name of the participants team.
+
+
+
+**Type**: subteamNames
+
+---
+
 #### position
 
 The participant's position in the team.
@@ -575,6 +645,16 @@ Whether the game ended in early surrender - a remake.
 
 
 **Type**: [Boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)
+
+---
+
+#### subteamPlacement
+
+Participants teams placement in the Arena gamemode.
+
+
+
+**Type**: [Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)
 
 ---
 

--- a/docs/content/2.api/1.classes/Team.md
+++ b/docs/content/2.api/1.classes/Team.md
@@ -41,7 +41,7 @@ Constructs a new instance of the `Team` class.
 
 #### bans
 
-The champions banned by the team.
+The champions banned by the team. Note: Bans in the Arena gamemode are shared across all teams.
 
 
 

--- a/docs/content/2.api/2.interfaces/ParticipantData.md
+++ b/docs/content/2.api/2.interfaces/ParticipantData.md
@@ -599,6 +599,54 @@ export interface ParticipantData
 
 ---
 
+#### placement
+
+
+
+**Type**: [Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)
+
+---
+
+#### playerAugment1
+
+
+
+**Type**: [Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)
+
+---
+
+#### playerAugment2
+
+
+
+**Type**: [Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)
+
+---
+
+#### playerAugment3
+
+
+
+**Type**: [Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)
+
+---
+
+#### playerAugment4
+
+
+
+**Type**: [Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)
+
+---
+
+#### playerSubteamId
+
+
+
+**Type**: [Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)
+
+---
+
 #### profileIcon
 
 
@@ -688,6 +736,14 @@ export interface ParticipantData
 ---
 
 #### spell4Casts
+
+
+
+**Type**: [Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)
+
+---
+
+#### subteamPlacement
 
 
 

--- a/src/structures/api/Match.ts
+++ b/src/structures/api/Match.ts
@@ -76,7 +76,7 @@ export class Match {
    *
    * They are mapped by their map sides (`blue` and `red`).
    */
-  readonly teams: Collection<'blue' | 'red', Team>;
+  readonly teams: Collection<'blue' | 'red' | 'Poro' | 'Minion' | 'Scuttle' | 'Krug', Team>;
   private readonly client: Client;
 
   /**
@@ -113,13 +113,33 @@ export class Match {
     this.region = this._regionFromPlatformId(data.info.platformId);
     this.queue = client.queues.find((q) => q.queueId === data.info.queueId)!;
     this.tournamentCode = data.info.tournamentCode;
+
     const blueTeamData = data.info.teams.find((t) => t.teamId === 100)!;
-    const redTeamData = data.info.teams.find((t) => t.teamId === 200)!;
-    const blueTeamParticipants = data.info.participants.filter((p) => p.teamId === 100);
-    const redTeamParticipants = data.info.participants.filter((p) => p.teamId === 200);
-    this.teams = new Collection<'blue' | 'red', Team>();
-    this.teams.set('blue', new Team(blueTeamData, blueTeamParticipants, champions, items, runeTrees, summonerSpells));
-    this.teams.set('red', new Team(redTeamData, redTeamParticipants, champions, items, runeTrees, summonerSpells));
+
+    // as per #70, it is not possible to check for the ARENA map the efficient way, so it is hardcoded
+    if (data.info.mapId === 30) {
+      const teamData = blueTeamData;
+      const poroTeamParticipants = data.info.participants.filter((p) => p.playerSubteamId === 1);
+      const minionTeamParticipants = data.info.participants.filter((p) => p.playerSubteamId === 2);
+      const scuttleTeamParticipants = data.info.participants.filter((p) => p.playerSubteamId === 3);
+      const krugTeamParticipants = data.info.participants.filter((p) => p.playerSubteamId === 4);
+      this.teams = new Collection<'Poro' | 'Minion' | 'Scuttle' | 'Krug', Team>();
+      this.teams.set('Poro', new Team(teamData, poroTeamParticipants, champions, items, runeTrees, summonerSpells));
+      this.teams.set('Minion', new Team(teamData, minionTeamParticipants, champions, items, runeTrees, summonerSpells));
+      this.teams.set(
+        'Scuttle',
+        new Team(teamData, scuttleTeamParticipants, champions, items, runeTrees, summonerSpells)
+      );
+      this.teams.set('Krug', new Team(teamData, krugTeamParticipants, champions, items, runeTrees, summonerSpells));
+    } else {
+      const redTeamData = data.info.teams.find((t) => t.teamId === 200)!;
+
+      const blueTeamParticipants = data.info.participants.filter((p) => p.teamId === 100);
+      const redTeamParticipants = data.info.participants.filter((p) => p.teamId === 200);
+      this.teams = new Collection<'blue' | 'red', Team>();
+      this.teams.set('blue', new Team(blueTeamData, blueTeamParticipants, champions, items, runeTrees, summonerSpells));
+      this.teams.set('red', new Team(redTeamData, redTeamParticipants, champions, items, runeTrees, summonerSpells));
+    }
   }
 
   /**

--- a/src/structures/api/Participant.ts
+++ b/src/structures/api/Participant.ts
@@ -5,6 +5,11 @@ import { Collection } from '@discordjs/collection';
 import { Perks } from './Perks';
 
 /**
+ * Team name of the participants team in the Arena gamemode.
+ */
+export type subteamNames = undefined | 'Poro' | 'Minion' | 'Scuttle' | 'Krug';
+
+/**
  * The participant's turret interaction information.
  */
 export interface ParticipantTurretStats {
@@ -418,6 +423,38 @@ export class Participant {
    */
   readonly physicalDamage: ParticipantDamageStats;
   /**
+   * Participants placement in the Arena gamemode.
+   */
+  readonly placement: number;
+  /**
+   * 1st participant augment in the Arena gamemode.
+   */
+  readonly playerAugment1: number;
+  /**
+   * 2nd participant augment in the Arena gamemode.
+   */
+  readonly playerAugment2: number;
+  /**
+   * 3rd participant augment in the Arena gamemode.
+   */
+  readonly playerAugment3: number;
+  /**
+   * 4th participant augment in the Arena gamemode.
+   */
+  readonly playerAugment4: number;
+  /**
+   * TeamId of the participant.
+   */
+  readonly playerSubteamId: number;
+  /**
+   * Team name of the participants team.
+   */
+  readonly playerSubteamName: subteamNames;
+  /**
+   * Participants teams placement in the Arena gamemode.
+   */
+  readonly subteamPlacement: number;
+  /**
    * Whether the participant killed the nexus.
    */
   readonly nexusKilled: boolean;
@@ -611,6 +648,15 @@ export class Participant {
       toChampions: data.physicalDamageDealtToChampions
     };
 
+    this.placement = data.placement;
+    this.playerAugment1 = data.playerAugment1;
+    this.playerAugment2 = data.playerAugment2;
+    this.playerAugment3 = data.playerAugment3;
+    this.playerAugment4 = data.playerAugment4;
+    this.playerSubteamId = data.playerSubteamId;
+    this.playerSubteamName = this._teamIdToTeamName(data.playerSubteamId);
+    this.subteamPlacement = data.subteamPlacement;
+
     this.trueDamage = {
       dealt: data.trueDamageDealt,
       taken: data.trueDamageTaken,
@@ -696,5 +742,20 @@ export class Participant {
       onTeam: data.totalHealsOnTeammates,
       units: data.totalUnitsHealed
     };
+  }
+
+  private _teamIdToTeamName(teamId: Number): subteamNames {
+    switch (teamId) {
+      case 1:
+        return 'Poro';
+      case 2:
+        return 'Minion';
+      case 3:
+        return 'Scuttle';
+      case 4:
+        return 'Krug';
+      default:
+        return undefined;
+    }
   }
 }

--- a/src/structures/api/Participant.ts
+++ b/src/structures/api/Participant.ts
@@ -3,11 +3,7 @@ import type { Champion, Item, RuneTree, SummonerSpell } from '../dragon';
 import { Bounty } from './Bounty';
 import { Collection } from '@discordjs/collection';
 import { Perks } from './Perks';
-
-/**
- * Team name of the participants team in the Arena gamemode.
- */
-export type subteamNames = undefined | 'Poro' | 'Minion' | 'Scuttle' | 'Krug';
+import { SubteamNames } from '../../types/api/Participant';
 
 /**
  * The participant's turret interaction information.
@@ -449,7 +445,7 @@ export class Participant {
   /**
    * Team name of the participants team.
    */
-  readonly playerSubteamName: subteamNames;
+  readonly playerSubteamName: SubteamNames;
   /**
    * Participants teams placement in the Arena gamemode.
    */
@@ -744,7 +740,7 @@ export class Participant {
     };
   }
 
-  private _teamIdToTeamName(teamId: Number): subteamNames {
+  private _teamIdToTeamName(teamId: Number): SubteamNames {
     switch (teamId) {
       case 1:
         return 'Poro';

--- a/src/structures/api/Team.ts
+++ b/src/structures/api/Team.ts
@@ -27,6 +27,7 @@ export class Team {
   readonly id: number;
   /**
    * The champions banned by the team.
+   * Note: Bans in the Arena gamemode are shared across all teams.
    */
   readonly bans: ChampionBan[];
   /**

--- a/src/types/api/Participant.ts
+++ b/src/types/api/Participant.ts
@@ -1,6 +1,11 @@
 import type { PerksData } from './Perks';
 
 /**
+ * Team name of the participants team in the Arena gamemode.
+ */
+export type SubteamNames = undefined | 'Poro' | 'Minion' | 'Scuttle' | 'Krug';
+
+/**
  * Match participant data as returned by the API
  */
 export interface ParticipantData {

--- a/src/types/api/Participant.ts
+++ b/src/types/api/Participant.ts
@@ -77,6 +77,13 @@ export interface ParticipantData {
   physicalDamageDealt: number;
   physicalDamageDealtToChampions: number;
   physicalDamageTaken: number;
+  placement: number;
+  playerAugment1: number;
+  playerAugment2: number;
+  playerAugment3: number;
+  playerAugment4: number;
+  playerSubteamId: number;
+  subteamPlacement: number;
   profileIcon: number;
   pushPings: number;
   puuid: string;


### PR DESCRIPTION
To fix #69, I have done the following steps
1. add Arena types
2. parse the Arena teamIds differently (now there is <'blue' | 'red' | 'Poro' | 'Minion' | 'Scuttle' | 'Krug'>)
3. run the documentation
---
I have the following issue upon extracting, maybe someone can help me with this one (or review the code): 
```
*** The target project appears to use TypeScript 5.1.5 which is newer than the bundled compiler engine; consider upgrading API Extractor.
Warning: src/structures/api/Participant.ts:448:3 - (ae-forgotten-export) The symbol "SubteamNames" needs to be exported by the entry point index.d.ts
```
---
The script was tested and worked (for me) for both arena and non arena games now, even tho an implantation of #70 would be useful. 