### PR TITLE
Updated methods to fix fetching league entries

### DIFF
--- a/docs/content/2.api/5.variables/methods.md
+++ b/docs/content/2.api/5.variables/methods.md
@@ -16,7 +16,7 @@ methods: {
     readonly CHAMPION: readonly ["getChampionInfo"];
     readonly CLASH: readonly ["getTeamById", "getPlayersBySummoner", "getTournaments", "getTournamentById", "getTournamentByTeam"];
     readonly LEAGUE_EXP: readonly ["getLeagueEntries"];
-    readonly LEAGUE: readonly ["getLeagueEntriesForSummoner", "getLeagueById"];
+    readonly LEAGUE: readonly ["getLeagueEntriesForSummoner", "getLeagueById", "getLeagueEntries", "getChallengerLeague", "getGrandmasterLeague", "getMasterLeague"];
     readonly LOL_CHALLENGES: readonly ["getAllChallengeConfigs", "getAllChallengePercentiles", "getChallengeConfigs", "getChallengeLeaderboards", "getChallengePercentiles", "getPlayerData"];
     readonly LOL_STATUS: readonly ["getPlatformData"];
     readonly MATCH: readonly ["getMatchIdsByPUUID", "getMatch", "getTimeline"];

--- a/src/ratelimiter/constants.ts
+++ b/src/ratelimiter/constants.ts
@@ -12,7 +12,14 @@ export const methods = {
   CHAMPION: ['getChampionInfo'],
   CLASH: ['getTeamById', 'getPlayersBySummoner', 'getTournaments', 'getTournamentById', 'getTournamentByTeam'],
   LEAGUE_EXP: ['getLeagueEntries'],
-  LEAGUE: ['getLeagueEntriesForSummoner', 'getLeagueById'],
+  LEAGUE: [
+    'getLeagueEntriesForSummoner',
+    'getLeagueById',
+    'getLeagueEntries',
+    'getChallengerLeague',
+    'getGrandmasterLeague',
+    'getMasterLeague'
+  ],
   LOL_CHALLENGES: [
     'getAllChallengeConfigs',
     'getAllChallengePercentiles',

--- a/src/ratelimiter/parseOptions.ts
+++ b/src/ratelimiter/parseOptions.ts
@@ -86,7 +86,11 @@ const parse = (opts: RateLimiterOptions): RateLimiterConfig => {
   if (Array.isArray(opts.methodLimit.LEAGUE))
     opts.methodLimit.LEAGUE = {
       getLeagueEntriesForSummoner: opts.methodLimit.LEAGUE,
-      getLeagueById: opts.methodLimit.LEAGUE
+      getLeagueById: opts.methodLimit.LEAGUE,
+      getLeagueEntries: opts.methodLimit.LEAGUE,
+      getChallengerLeague: opts.methodLimit.LEAGUE,
+      getGrandmasterLeague: opts.methodLimit.LEAGUE,
+      getMasterLeague: opts.methodLimit.LEAGUE
     };
 
   if (Array.isArray(opts.methodLimit.LOL_STATUS))


### PR DESCRIPTION
Currently cannot fetch league entries by queue/tier, it results in the error found below because the methods aren't updated. This PR fixes the issue, tests are passing for fetching by queue/tier.

```console
[2023-07-31T19:41:03.797Z] TRACE    :: Fetching league entries for summoner ID: 1KuPmUvQrrkvsL-r3XONyvHKz8EADUor59riM-GdUtop_76q from API.
- error node_modules/.pnpm/shieldbow@2.2.0/node_modules/shieldbow/dist/ratelimiter/limiter.js (149:43) @ length
- error unhandledRejection: Error [TypeError]: Cannot read properties of undefined (reading 'length')
    at RateLimiter._checkMethodLimit (webpack-internal:///(rsc)/./node_modules/.pnpm/shieldbow@2.2.0/node_modules/shieldbow/dist/ratelimiter/limiter.js:150:44)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async RateLimiter._check (webpack-internal:///(rsc)/./node_modules/.pnpm/shieldbow@2.2.0/node_modules/shieldbow/dist/ratelimiter/limiter.js:115:29)
    at async eval (webpack-internal:///(rsc)/./node_modules/.pnpm/shieldbow@2.2.0/node_modules/shieldbow/dist/ratelimiter/limiter.js:91:27) {
  digest: undefined
}
null
```