### PR TITLE
Rewrite/ratelimiter

### DIFF
--- a/.changeset/big-carrots-hide.md
+++ b/.changeset/big-carrots-hide.md
@@ -1,0 +1,5 @@
+---
+"@shieldbow/ratelimiter": major
+---
+
+First working version.

--- a/.changeset/big-carrots-hide.md
+++ b/.changeset/big-carrots-hide.md
@@ -2,4 +2,14 @@
 "@shieldbow/ratelimiter": major
 ---
 
-First working version.
+# First working version.
+
+First working version of the rate limiter.
+
+Included features:
+
+- Reading rate limits from the headers.
+- Multiple rate limiting strategies - 'spread' and 'burst'.
+- Allowing throw on rate limit instead of forced waits.
+- Allowing custom cache implementations.
+- 100% test coverage.

--- a/.changeset/funny-pumas-visit.md
+++ b/.changeset/funny-pumas-visit.md
@@ -1,5 +1,0 @@
----
-"@shieldbow/ratelimiter": patch
----
-
-First publish, registering name, testing multi-publish

--- a/.changeset/funny-pumas-visit.md
+++ b/.changeset/funny-pumas-visit.md
@@ -1,0 +1,5 @@
+---
+"@shieldbow/ratelimiter": patch
+---
+
+First publish, registering name, testing multi-publish

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "devDependencies": {
     "@changesets/cli": "^2.26.2",
+    "@shieldbow/ratelimiter": "workspace:^",
     "@shieldbow/web": "workspace:^",
     "turbo": "^1.10.15"
   },

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   },
   "scripts": {
     "build": "turbo run build --no-daemon",
-    "test": "turbo run test --no-daemon"
+    "test": "turbo run test --no-daemon",
+		"change": "changeset",
+		"bump": "changeset version",
+		"release": "changeset publish"
   }
 }

--- a/packages/ratelimiter/.eslintrc.json
+++ b/packages/ratelimiter/.eslintrc.json
@@ -1,0 +1,37 @@
+{
+  "parser": "@typescript-eslint/parser",
+  "env": {
+    "node": true,
+    "es2021": true,
+    "jest": true
+  },
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "rules": {
+    "linebreak-style": ["error", "unix"],
+    "no-duplicate-imports": "error",
+    "no-async-promise-executor": "off",
+    "no-use-before-define": "error",
+    "curly": ["error", "multi"],
+    "dot-notation": "error",
+    "eqeqeq": ["error", "always"],
+    "prefer-arrow-callback": "error",
+    "prefer-const": "error",
+    "multiline-ternary": ["error", "always-multiline"],
+    "no-extra-parens": ["error", "all", { "nestedBinaryExpressions": false }],
+    "no-trailing-spaces": ["error", { "skipBlankLines": true }],
+    "prettier/prettier": 2,
+    "no-unused-vars": "off",
+    "max-len": [
+      "error",
+      120,
+      { "ignoreTemplateLiterals": true, "ignoreUrls": true }
+    ],
+    "no-case-declarations": "off"
+  },
+  "extends": ["eslint:recommended", "prettier"],
+  "plugins": ["prettier"],
+  "noInlineConfig": true
+}

--- a/packages/ratelimiter/.prettierrc.json
+++ b/packages/ratelimiter/.prettierrc.json
@@ -1,0 +1,9 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "none",
+  "bracketSpacing": true,
+  "printWidth": 120,
+  "endOfLine": "lf"
+}

--- a/packages/ratelimiter/CHANGELOG.md
+++ b/packages/ratelimiter/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @shieldbow/ratelimiter
+
+## 0.0.2
+
+### Patch Changes
+
+- 39b635e4: First publish, registering name, testing multi-publish

--- a/packages/ratelimiter/README.md
+++ b/packages/ratelimiter/README.md
@@ -1,0 +1,27 @@
+# Shieldbow ratelimiter
+
+The ratelimiter package provides a rate limiter for the RIOT Games API.
+
+It is not meant to be used by itself, instead use the `shieldbow` package.
+
+---
+
+If, for some reason, you want to use just the ratelimiter, it can be installed by itself using:
+
+```bash
+$ npm install @shieldbow/ratelimiter
+
+$ yarn add @shieldbow/ratelimiter
+
+$ pnpm add @shieldbow/ratelimiter
+```
+
+This package is part of the shieldbow library.
+
+The shieldbow library allows you to easily interact with various aspects of the RIOT Games API
+to develop third-party apps and services for League of Legends (LoL) and Teamfight Tactics (TFT).
+
+This package is used to provide a rate limiter for the shieldbow library, which is capable of
+handling the rate limits imposed by the RIOT Games API, and detects the rate limits automatically
+from the headers, provides manual overrides, and more.
+

--- a/packages/ratelimiter/api-extractor.json
+++ b/packages/ratelimiter/api-extractor.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
+  "mainEntryPointFilePath": "<projectFolder>/dist/index.d.ts",
+  "bundledPackages": [],
+  "compiler": {},
+  "apiReport": {
+    "enabled": false
+  },
+  "docModel": {
+    "enabled": true,
+    "apiJsonFilePath": "<projectFolder>/../docs/<unscopedPackageName>.api.json"
+  },
+  "dtsRollup": {
+    "enabled": false
+  },
+  "tsdocMetadata": {
+    "enabled": false
+  },
+  "messages": {
+    "compilerMessageReporting": {
+      "default": {
+        "logLevel": "warning"
+      }
+    },
+    "extractorMessageReporting": {
+      "default": {
+        "logLevel": "warning"
+      },
+      "ae-missing-release-tag": {
+        "logLevel": "none"
+      }
+    },
+    "tsdocMessageReporting": {
+      "default": {
+        "logLevel": "warning"
+      }
+    }
+  }
+}

--- a/packages/ratelimiter/jest.config.ts
+++ b/packages/ratelimiter/jest.config.ts
@@ -1,0 +1,22 @@
+export default {
+  extensionsToTreatAsEsm: ['.ts'],
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.ts$': [
+      'ts-jest',
+      {
+        tsconfig: 'tsconfig.test.json',
+        useESM: true
+      }
+    ]
+  },
+  clearMocks: true,
+  collectCoverage: true,
+  coverageDirectory: 'coverage',
+  coverageReporters: ['html', 'text-summary', 'cobertura'],
+  coverageProvider: 'v8',
+  testTimeout: 30000,
+  slowTestThreshold: 15,
+  verbose: true
+};

--- a/packages/ratelimiter/package.json
+++ b/packages/ratelimiter/package.json
@@ -56,7 +56,7 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "@shieldbow/web": "workspace:^",
+    "@shieldbow/cache": "workspace:^",
     "tslib": "^2.6.2"
   }
 }

--- a/packages/ratelimiter/package.json
+++ b/packages/ratelimiter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shieldbow/ratelimiter",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "The ratelimiter for the shieldbow library",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/ratelimiter/package.json
+++ b/packages/ratelimiter/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@shieldbow/ratelimiter",
+  "version": "0.0.1",
+  "description": "The ratelimiter for the shieldbow library",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc && tsc-alias",
+    "watch": "tsc && (concurrently \"tsc -w\" \"tsc-alias -w\")",
+    "format": "prettier --write \"src/**/**.ts\"",
+    "lint": "eslint --fix --color \"src/**/**.ts\"",
+    "format:test": "prettier --check \"src/**/**.ts\"",
+    "lint:test": "eslint --color \"src/**/**.ts\"",
+    "pretest": "run-s format:test lint:test build",
+    "test": "jest --runInBand",
+    "extract": "api-extractor run"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TheDrone7/shieldbow.git"
+  },
+  "keywords": [
+    "lol",
+    "shieldbow",
+    "league",
+    "leagueoflegends",
+    "typescript",
+    "ts",
+    "javascript",
+    "js",
+    "ratelimiter"
+  ],
+  "author": "TheDrone7 <h@thedrone7.dev> (https://thedrone7.dev)",
+  "license": "GPL-3.0",
+  "bugs": {
+    "url": "https://github.com/TheDrone7/shieldbow/issues"
+  },
+  "files": [
+    "dist"
+  ],
+  "homepage": "https://github.com/TheDrone7/shieldbow#readme",
+  "devDependencies": {
+    "@microsoft/api-extractor": "^7.38.0",
+    "@types/jest": "^29.5.5",
+    "@typescript-eslint/parser": "^6.7.4",
+    "concurrently": "^8.2.1",
+    "eslint": "^8.50.0",
+    "eslint-config-prettier": "^8.10.0",
+    "eslint-plugin-prettier": "^5.0.0",
+    "jest": "^29.7.0",
+    "jest-junit": "^16.0.0",
+    "npm-run-all": "^4.1.5",
+    "prettier": "^3.0.3",
+    "ts-jest": "^29.1.1",
+    "ts-node": "^10.9.1",
+    "tsc-alias": "^1.8.8",
+    "typescript": "^5.2.2"
+  },
+  "dependencies": {
+    "@shieldbow/web": "workspace:^"
+  }
+}

--- a/packages/ratelimiter/package.json
+++ b/packages/ratelimiter/package.json
@@ -56,6 +56,7 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "@shieldbow/web": "workspace:^"
+    "@shieldbow/web": "workspace:^",
+    "tslib": "^2.6.2"
   }
 }

--- a/packages/ratelimiter/src/error.ts
+++ b/packages/ratelimiter/src/error.ts
@@ -1,0 +1,20 @@
+import { IRateLimit } from './types';
+
+/**
+ * An error class for the RateLimiter.
+ */
+export class ShieldbowRateLimiterError extends Error {
+  /**
+   * Creates (and throws) a new RateLimiterError instance.
+   * @param method - The method that was rate limited.
+   * @param limit - The rate limit that was exceeded.
+   */
+  constructor(method: string, limits: IRateLimit) {
+    let message = `Rate limit exceeded for ${method === 'app' ? 'the' : 'method'} '${method}' with limit '${
+      limits.limit
+    } / ${limits.duration}ms'.`;
+    message += `\nCurrent count: ${limits.count}, resets at ${new Date(limits.reset).toISOString()}.`;
+    super(message);
+    this.name = 'Shieldbow Rate Limiter Error';
+  }
+}

--- a/packages/ratelimiter/src/index.ts
+++ b/packages/ratelimiter/src/index.ts
@@ -1,0 +1,15 @@
+import { Client } from '@shieldbow/web';
+
+/**
+ * The RateLimiter class.
+ */
+export default class RateLimiter {
+  readonly client: Client;
+  /**
+   * Creates a new RateLimiter instance.
+   */
+  constructor(client: Client) {
+    this.client = client;
+    console.log('RateLimiter constructor');
+  }
+}

--- a/packages/ratelimiter/src/index.ts
+++ b/packages/ratelimiter/src/index.ts
@@ -1,2 +1,3 @@
 export * from './limiter';
 export * from './types';
+export * from './error';

--- a/packages/ratelimiter/src/index.ts
+++ b/packages/ratelimiter/src/index.ts
@@ -1,15 +1,2 @@
-import { Client } from '@shieldbow/web';
-
-/**
- * The RateLimiter class.
- */
-export default class RateLimiter {
-  readonly client: Client;
-  /**
-   * Creates a new RateLimiter instance.
-   */
-  constructor(client: Client) {
-    this.client = client;
-    console.log('RateLimiter constructor');
-  }
-}
+export * from './limiter';
+export * from './types';

--- a/packages/ratelimiter/src/limiter.ts
+++ b/packages/ratelimiter/src/limiter.ts
@@ -116,7 +116,7 @@ export class RateLimiter {
         else await new Promise((resolve) => setTimeout(resolve, limit.reset - Date.now()));
         continue;
       } else if (this._strategy === 'spread') {
-        const timeRemaining = Date.now() - limit.reset;
+        const timeRemaining = limit.reset - Date.now();
         const requestsRemaining = limit.limit - limit.count;
         const timePerRequest = timeRemaining / requestsRemaining;
         waitTimes.push(timePerRequest);

--- a/packages/ratelimiter/src/limiter.ts
+++ b/packages/ratelimiter/src/limiter.ts
@@ -1,0 +1,111 @@
+import type { ICache } from '@shieldbow/web';
+import type { IRateLimit, ILimitUsage, IRateLimiterConfig, RateLimitStrategy } from 'types';
+
+/**
+ * The RateLimiter class.
+ */
+export class RateLimiter {
+  private readonly _cache: ICache;
+  private _strategy: RateLimitStrategy;
+  private readonly _keyPrefix: string = 'shieldbow:ratelimit:';
+
+  /**
+   * Creates a new RateLimiter instance.
+   *
+   * @param config - The configuration for the RateLimiter.
+   */
+  constructor(config: IRateLimiterConfig) {
+    this._cache = config.cache;
+    this._strategy = config.strategy || 'burst';
+  }
+
+  /**
+   * Set application rate limits.
+   *
+   * @param header - The header string.
+   */
+  async setAppLimits(header: string) {
+    const limits = this.parseRateLimitHeader(header);
+    await this._cache.set(`${this._keyPrefix}app:limit`, limits);
+  }
+
+  /**
+   * Get application rate limits.
+   *
+   * @returns The app rate limits from the cache.
+   */
+  async getAppLimits() {
+    return await this._cache.get<IRateLimit[]>(`${this._keyPrefix}app:limit`);
+  }
+
+  /**
+   * Set method rate limit for a specific method.
+   * @param method - The method to set the limits for.
+   * @param header - The method limit header.
+   */
+  async setMethodLimits(method: string, header: string) {
+    const limits = this.parseRateLimitHeader(header);
+    await this._cache.set(`${this._keyPrefix}method:${method}:limit`, limits);
+  }
+
+  /**
+   * Get method rate limit for a specific method.
+   * @param method - The method to get the limits for.
+   * @returns The method rate limits for the method.
+   */
+  async getMethodLimits(method: string) {
+    return await this._cache.get<IRateLimit[]>(`${this._keyPrefix}method:${method}:limit`);
+  }
+
+  /**
+   * Fetch the limit from the cache.
+   * @returns The number of requests that have been made for the app.
+   */
+  async getAppUsage() {
+    return await this._cache.get<ILimitUsage[]>(`${this._keyPrefix}app:usage`);
+  }
+
+  /**
+   * Get method usage for a specific method.
+   *
+   * @param method - The method to get the limits for.
+   * @returns The number of requests that have been made for the method.
+   */
+  async getMethodUsage(method: string) {
+    return await this._cache.get<ILimitUsage[]>(`${this._keyPrefix}method:${method}:usage`);
+  }
+
+  /**
+   * Set the app limit usage.
+   *
+   * @param usage - The usages to set.
+   */
+  async setAppUsage(usage: ILimitUsage[]) {
+    await this._cache.set(`${this._keyPrefix}app:usage`, usage);
+  }
+
+  /**
+   * Set method usage for a specific method.
+   *
+   * @param method - The method to set the usage for.
+   * @param usage - The usages to set.
+   */
+  async setMethodUsage(method: string, usage: ILimitUsage[]) {
+    await this._cache.set(`${this._keyPrefix}method:${method}:usage`, usage);
+  }
+
+  /**
+   * Parses the rate limit header value.
+   *
+   * @param header - The header value to parse.
+   * @returns The parsed rate limits.
+   */
+  parseRateLimitHeader(header: string): IRateLimit[] {
+    return header.split(',').map((limit) => ({
+      limit: parseInt(limit.split(':')[0]),
+      duration: parseInt(limit.split(':')[1])
+    }));
+  }
+
+  async waitForAppLimit() {}
+}

--- a/packages/ratelimiter/src/limiter.ts
+++ b/packages/ratelimiter/src/limiter.ts
@@ -1,5 +1,6 @@
 import type { ICache } from '@shieldbow/cache';
 import type { IRateLimit, IRateLimiterConfig, RateLimitStrategy } from 'types';
+import { ShieldbowRateLimiterError } from './error';
 
 /**
  * The RateLimiter class.
@@ -90,7 +91,7 @@ export class RateLimiter {
     for (const limit of limits)
       if (limit.reset < Date.now()) continue;
       else if (limit.count >= limit.limit) {
-        if (this._throwOnLimit) throw new Error('[Shieldbow ratelimiter]: Rate limit exceeded.');
+        if (this._throwOnLimit) throw new ShieldbowRateLimiterError('app', limit);
         else await new Promise((resolve) => setTimeout(resolve, limit.reset - Date.now()));
         continue;
       } else if (this._strategy === 'spread') {
@@ -114,7 +115,7 @@ export class RateLimiter {
     for (const limit of limits)
       if (limit.reset < Date.now()) continue;
       else if (limit.count >= limit.limit) {
-        if (this._throwOnLimit) throw new Error('[Shieldbow ratelimiter]: Rate limit exceeded.');
+        if (this._throwOnLimit) throw new ShieldbowRateLimiterError(method, limit);
         else await new Promise((resolve) => setTimeout(resolve, limit.reset - Date.now()));
         continue;
       } else if (this._strategy === 'spread') {

--- a/packages/ratelimiter/src/types/config.ts
+++ b/packages/ratelimiter/src/types/config.ts
@@ -1,4 +1,4 @@
-import { ICache } from '@shieldbow/web';
+import { ICache } from '@shieldbow/cache';
 
 /**
  * Rate limit strategy
@@ -17,4 +17,15 @@ export interface IRateLimiterConfig {
    * The rate limit strategy to use.
    */
   strategy?: RateLimitStrategy;
+
+  /**
+   * Whether or not to throw an error when the rate limit is exceeded.
+   *
+   * If true, an error will be thrown.
+   *
+   * If false, the program will halt until the rate limit is reset.
+   *
+   * Defaults to false.
+   */
+  throwOnLimit?: boolean;
 }

--- a/packages/ratelimiter/src/types/config.ts
+++ b/packages/ratelimiter/src/types/config.ts
@@ -1,0 +1,20 @@
+import { ICache } from '@shieldbow/web';
+
+/**
+ * Rate limit strategy
+ * burst: Allow the maximum number of requests per period to be made at once.
+ * spread: Spread the maximum number of requests per period out evenly.
+ */
+export type RateLimitStrategy = 'burst' | 'spread';
+
+export interface IRateLimiterConfig {
+  /**
+   * The cache mechanism to use.
+   */
+  cache: ICache;
+
+  /**
+   * The rate limit strategy to use.
+   */
+  strategy?: RateLimitStrategy;
+}

--- a/packages/ratelimiter/src/types/index.ts
+++ b/packages/ratelimiter/src/types/index.ts
@@ -1,2 +1,2 @@
-export { IRateLimit, ILimitUsage } from './limit';
+export { IRateLimit } from './limit';
 export { RateLimitStrategy, IRateLimiterConfig } from './config';

--- a/packages/ratelimiter/src/types/index.ts
+++ b/packages/ratelimiter/src/types/index.ts
@@ -1,0 +1,2 @@
+export { IRateLimit, ILimitUsage } from './limit';
+export { RateLimitStrategy, IRateLimiterConfig } from './config';

--- a/packages/ratelimiter/src/types/limit.ts
+++ b/packages/ratelimiter/src/types/limit.ts
@@ -1,0 +1,34 @@
+/**
+ * The rate limit for a given period.
+ */
+export interface IRateLimit {
+  /**
+   * The maximum number of requests allowed in the current period.
+   */
+  limit: number;
+
+  /**
+   * The time period in milliseconds.
+   */
+  duration: number;
+}
+
+/**
+ * The usage of a given rate limit.
+ */
+export interface ILimitUsage {
+  /**
+   * The number of requests that have been made.
+   */
+  count: number;
+
+  /**
+   * The time (in milliseconds) in which this should be reset.
+   */
+  reset: number;
+
+  /**
+   * The time period in milliseconds for the limit (to associate with the limits).
+   */
+  duration: number;
+}

--- a/packages/ratelimiter/src/types/limit.ts
+++ b/packages/ratelimiter/src/types/limit.ts
@@ -11,24 +11,14 @@ export interface IRateLimit {
    * The time period in milliseconds.
    */
   duration: number;
-}
 
-/**
- * The usage of a given rate limit.
- */
-export interface ILimitUsage {
   /**
    * The number of requests that have been made.
    */
   count: number;
 
   /**
-   * The time (in milliseconds) in which this should be reset.
+   * The timestamp at which this should be reset.
    */
   reset: number;
-
-  /**
-   * The time period in milliseconds for the limit (to associate with the limits).
-   */
-  duration: number;
 }

--- a/packages/ratelimiter/tests/burst.test.ts
+++ b/packages/ratelimiter/tests/burst.test.ts
@@ -1,0 +1,36 @@
+import { ShieldbowMemoryCache } from '@shieldbow/cache';
+import { RateLimiter } from '../dist';
+
+const sampleHeaders = '1:5,10:10,60:20';
+const nullCounts = '0:5,0:10,0:20';
+const sampleCounts = '1:5,1:10,1:20';
+
+describe('RL: Burst', () => {
+  const limiter = new RateLimiter({
+    cache: new ShieldbowMemoryCache()
+  });
+
+  it('should parse rate limit headers', () => {
+    const limits = limiter.parseRateLimitHeader(sampleHeaders, sampleCounts);
+    expect(limits).toHaveLength(3);
+    expect(limits).toEqual(expect.arrayContaining([expect.objectContaining({ limit: 1, duration: 5000, count: 1 })]));
+    expect(limits).toEqual(expect.arrayContaining([expect.objectContaining({ limit: 10, duration: 10000, count: 1 })]));
+    expect(limits).toEqual(expect.arrayContaining([expect.objectContaining({ limit: 60, duration: 20000, count: 1 })]));
+  });
+
+  it('should not wait for rate limit to reset when counts are 0', async () => {
+    const start = Date.now();
+    limiter.setAppLimits(sampleHeaders, nullCounts);
+    await limiter.waitForLimit('something');
+    const end = Date.now();
+    expect(end - start).toBeLessThan(1000);
+  });
+
+  it('should wait for rate limit to reset', async () => {
+    const start = Date.now();
+    limiter.setAppLimits(sampleHeaders, sampleCounts);
+    await limiter.waitForLimit('something');
+    const end = Date.now();
+    expect(end - start).toBeGreaterThanOrEqual(5000);
+  });
+});

--- a/packages/ratelimiter/tests/jsconfig.json
+++ b/packages/ratelimiter/tests/jsconfig.json
@@ -1,0 +1,18 @@
+{
+	"compilerOptions": {
+		"module": "ESNext",
+		"moduleResolution": "Node",
+		"target": "ES2020",
+		"jsx": "react",
+		"allowImportingTsExtensions": true,
+		"strictNullChecks": true,
+		"strictFunctionTypes": true,
+	},
+	"exclude": [
+		"node_modules",
+		"**/node_modules/*"
+	],
+	"typeAcquisition": {
+		"include": ["jest"]
+	}
+}

--- a/packages/ratelimiter/tests/methods.test.ts
+++ b/packages/ratelimiter/tests/methods.test.ts
@@ -1,0 +1,33 @@
+import { ShieldbowMemoryCache } from '@shieldbow/cache';
+import { RateLimiter } from '../dist';
+
+const methodName = 'something';
+const sampleHeaders = '2:5,10:10,60:20';
+const nullCounts = '0:5,0:10,0:20';
+const sampleCounts = '2:5,2:10,2:20';
+
+describe('RL: Method limits (spread only)', () => {
+  const limiter = new RateLimiter({
+    cache: new ShieldbowMemoryCache(),
+    strategy: 'spread'
+  });
+
+  it('should spread requests even when limits are 0', async () => {
+    const start = Date.now();
+    limiter.setMethodLimits(methodName, sampleHeaders, nullCounts);
+    await limiter.waitForLimit(methodName);
+    const end = Date.now();
+    // The number should be around 2500 because
+    // the limit is 2 requests per 5 seconds.
+    expect(end - start).toBeGreaterThan(2000);
+    expect(end - start).toBeLessThan(3000);
+  });
+
+  it('should wait for rate limit to reset', async () => {
+    const start = Date.now();
+    limiter.setMethodLimits(methodName, sampleHeaders, sampleCounts);
+    await limiter.waitForLimit(methodName);
+    const end = Date.now();
+    expect(end - start).toBeGreaterThanOrEqual(5000);
+  });
+});

--- a/packages/ratelimiter/tests/misc.test.ts
+++ b/packages/ratelimiter/tests/misc.test.ts
@@ -14,9 +14,7 @@ describe('RL: Extra features', () => {
   it('should throw error instead of waiting for rate limit to reset', async () => {
     const start = Date.now();
     limiter.setAppLimits(sampleHeaders, sampleCounts);
-    expect(() => limiter.waitForLimit('something')).rejects.toThrowError(
-      '[Shieldbow ratelimiter]: Rate limit exceeded.'
-    );
+    expect(() => limiter.waitForLimit('something')).rejects.toThrowError();
     const end = Date.now();
     expect(end - start).toBeLessThanOrEqual(1000);
   });
@@ -25,9 +23,7 @@ describe('RL: Extra features', () => {
     const start = Date.now();
     limiter.setAppLimits(sampleHeaders, nullCounts);
     limiter.setMethodLimits('something', sampleHeaders, sampleCounts);
-    expect(() => limiter.waitForLimit('something')).rejects.toThrowError(
-      '[Shieldbow ratelimiter]: Rate limit exceeded.'
-    );
+    expect(() => limiter.waitForLimit('something')).rejects.toThrowError();
     const end = Date.now();
     expect(end - start).toBeLessThanOrEqual(1000);
   });

--- a/packages/ratelimiter/tests/misc.test.ts
+++ b/packages/ratelimiter/tests/misc.test.ts
@@ -1,0 +1,34 @@
+import { ShieldbowMemoryCache } from '@shieldbow/cache';
+import { RateLimiter } from '../dist';
+
+const sampleHeaders = '2:5,10:10,60:20';
+const nullCounts = '0:5,0:10,0:20';
+const sampleCounts = '2:5,2:10,2:20';
+
+describe('RL: Extra features', () => {
+  const limiter = new RateLimiter({
+    cache: new ShieldbowMemoryCache(),
+    throwOnLimit: true
+  });
+
+  it('should throw error instead of waiting for rate limit to reset', async () => {
+    const start = Date.now();
+    limiter.setAppLimits(sampleHeaders, sampleCounts);
+    expect(() => limiter.waitForLimit('something')).rejects.toThrowError(
+      '[Shieldbow ratelimiter]: Rate limit exceeded.'
+    );
+    const end = Date.now();
+    expect(end - start).toBeLessThanOrEqual(1000);
+  });
+
+  it('should throw error instead of waiting for method rate limit to reset', async () => {
+    const start = Date.now();
+    limiter.setAppLimits(sampleHeaders, nullCounts);
+    limiter.setMethodLimits('something', sampleHeaders, sampleCounts);
+    expect(() => limiter.waitForLimit('something')).rejects.toThrowError(
+      '[Shieldbow ratelimiter]: Rate limit exceeded.'
+    );
+    const end = Date.now();
+    expect(end - start).toBeLessThanOrEqual(1000);
+  });
+});

--- a/packages/ratelimiter/tests/spread.test.ts
+++ b/packages/ratelimiter/tests/spread.test.ts
@@ -30,6 +30,18 @@ describe('RL: Spread', () => {
     expect(end - start).toBeLessThan(3000);
   });
 
+  it('should spread requests but not overdo it (might double if both app and method are set)', async () => {
+    const start = Date.now();
+    limiter.setAppLimits(sampleHeaders, nullCounts);
+    limiter.setMethodLimits('something', sampleHeaders, nullCounts);
+    await limiter.waitForLimit('something');
+    const end = Date.now();
+    // The number should be around 2500 because
+    // the limit is 2 requests per 5 seconds.
+    expect(end - start).toBeGreaterThan(2000);
+    expect(end - start).toBeLessThan(3000);
+  });
+
   it('should wait for rate limit to reset', async () => {
     const start = Date.now();
     limiter.setAppLimits(sampleHeaders, sampleCounts);

--- a/packages/ratelimiter/tests/spread.test.ts
+++ b/packages/ratelimiter/tests/spread.test.ts
@@ -1,0 +1,40 @@
+import { ShieldbowMemoryCache } from '@shieldbow/cache';
+import { RateLimiter } from '../dist';
+
+const sampleHeaders = '2:5,10:10,60:20';
+const nullCounts = '0:5,0:10,0:20';
+const sampleCounts = '2:5,2:10,2:20';
+
+describe('RL: Spread', () => {
+  const limiter = new RateLimiter({
+    cache: new ShieldbowMemoryCache(),
+    strategy: 'spread'
+  });
+
+  it('should parse rate limit headers', () => {
+    const limits = limiter.parseRateLimitHeader(sampleHeaders, sampleCounts);
+    expect(limits).toHaveLength(3);
+    expect(limits).toEqual(expect.arrayContaining([expect.objectContaining({ limit: 2, duration: 5000, count: 2 })]));
+    expect(limits).toEqual(expect.arrayContaining([expect.objectContaining({ limit: 10, duration: 10000, count: 2 })]));
+    expect(limits).toEqual(expect.arrayContaining([expect.objectContaining({ limit: 60, duration: 20000, count: 2 })]));
+  });
+
+  it('should spread requests even when limits are 0', async () => {
+    const start = Date.now();
+    limiter.setAppLimits(sampleHeaders, nullCounts);
+    await limiter.waitForLimit('something');
+    const end = Date.now();
+    // The number should be around 2500 because
+    // the limit is 2 requests per 5 seconds.
+    expect(end - start).toBeGreaterThan(2000);
+    expect(end - start).toBeLessThan(3000);
+  });
+
+  it('should wait for rate limit to reset', async () => {
+    const start = Date.now();
+    limiter.setAppLimits(sampleHeaders, sampleCounts);
+    await limiter.waitForLimit('something');
+    const end = Date.now();
+    expect(end - start).toBeGreaterThanOrEqual(5000);
+  });
+});

--- a/packages/ratelimiter/tsconfig.json
+++ b/packages/ratelimiter/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "./src",
+    "rootDir": "src",
+    "outDir": "dist",
+    "paths": {
+      "types/*": ["types/*"],
+      "utilties/*": ["utilties/*"],
+      "structures/*": ["structures/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/packages/ratelimiter/tsconfig.test.json
+++ b/packages/ratelimiter/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "tests",
+    "noEmit": true
+  },
+  "include": ["src", "tests"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@shieldbow/web':
         specifier: workspace:^
         version: link:../web
+      tslib:
+        specifier: ^2.6.2
+        version: 2.6.2
     devDependencies:
       '@microsoft/api-extractor':
         specifier: ^7.38.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,12 +11,12 @@ importers:
       '@changesets/cli':
         specifier: ^2.26.2
         version: 2.26.2
-      '@shieldbow/ratelimiter':
-        specifier: workspace:^
-        version: link:packages/ratelimiter
       '@shieldbow/cache':
         specifier: workspace:^
         version: link:packages/cache
+      '@shieldbow/ratelimiter':
+        specifier: workspace:^
+        version: link:packages/ratelimiter
       '@shieldbow/web':
         specifier: workspace:^
         version: link:packages/web
@@ -84,9 +84,9 @@ importers:
 
   packages/ratelimiter:
     dependencies:
-      '@shieldbow/web':
+      '@shieldbow/cache':
         specifier: workspace:^
-        version: link:../web
+        version: link:../cache
       tslib:
         specifier: ^2.6.2
         version: 2.6.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,12 +11,67 @@ importers:
       '@changesets/cli':
         specifier: ^2.26.2
         version: 2.26.2
+      '@shieldbow/ratelimiter':
+        specifier: workspace:^
+        version: link:packages/ratelimiter
       '@shieldbow/web':
         specifier: workspace:^
         version: link:packages/web
       turbo:
         specifier: ^1.10.15
         version: 1.10.15
+
+  packages/ratelimiter:
+    dependencies:
+      '@shieldbow/web':
+        specifier: workspace:^
+        version: link:../web
+    devDependencies:
+      '@microsoft/api-extractor':
+        specifier: ^7.38.0
+        version: 7.38.0(@types/node@20.8.6)
+      '@types/jest':
+        specifier: ^29.5.5
+        version: 29.5.5
+      '@typescript-eslint/parser':
+        specifier: ^6.7.4
+        version: 6.7.5(eslint@8.51.0)(typescript@5.2.2)
+      concurrently:
+        specifier: ^8.2.1
+        version: 8.2.1
+      eslint:
+        specifier: ^8.50.0
+        version: 8.51.0
+      eslint-config-prettier:
+        specifier: ^8.10.0
+        version: 8.10.0(eslint@8.51.0)
+      eslint-plugin-prettier:
+        specifier: ^5.0.0
+        version: 5.0.1(eslint-config-prettier@8.10.0)(eslint@8.51.0)(prettier@3.0.3)
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@20.8.6)(ts-node@10.9.1)
+      jest-junit:
+        specifier: ^16.0.0
+        version: 16.0.0
+      npm-run-all:
+        specifier: ^4.1.5
+        version: 4.1.5
+      prettier:
+        specifier: ^3.0.3
+        version: 3.0.3
+      ts-jest:
+        specifier: ^29.1.1
+        version: 29.1.1(@babel/core@7.23.2)(jest@29.7.0)(typescript@5.2.2)
+      ts-node:
+        specifier: ^10.9.1
+        version: 10.9.1(@types/node@20.8.6)(typescript@5.2.2)
+      tsc-alias:
+        specifier: ^1.8.8
+        version: 1.8.8
+      typescript:
+        specifier: ^5.2.2
+        version: 5.2.2
 
   packages/web:
     dependencies:

--- a/shieldbow.code-workspace
+++ b/shieldbow.code-workspace
@@ -18,8 +18,7 @@
     ],
     "settings": {
         "jest.disabledWorkspaceFolders": [
-					"shieldbow",
-					"rate-limiter"
+					"shieldbow"
 				]
     }
 }

--- a/shieldbow.code-workspace
+++ b/shieldbow.code-workspace
@@ -6,9 +6,16 @@
         {
             "name": "web",
             "path": "packages/web"
+        },
+        {
+            "name": "rate-limiter",
+            "path": "packages/ratelimiter"
         }
     ],
     "settings": {
-        "jest.disabledWorkspaceFolders": ["shieldbow"]
+        "jest.disabledWorkspaceFolders": [
+					"shieldbow",
+					"rate-limiter"
+				]
     }
 }


### PR DESCRIPTION
# REWRITE V3 - RATE LIMITER

This will be done over a series of pull requests and changes that eventually reduce shieldbow into smaller packages in a monorepo.

This is the third of the series. Introducing shieldbow ratelimiter, the ratelimiter is being separated into its own package for better control and availability as a standalone package.

Roadmap before release of `@shieldbow/ratelimiter` v1.0
- [x] Limiter
- [x] Reading headers
- [x] Ability to limit actions
- [x] Ability to make concurrent requests without exceeding limit
- [x] Caching
- [x] Testing
- [x] Docs
- [x] Monorepo automation


---